### PR TITLE
renaming academic cluster

### DIFF
--- a/form.yml
+++ b/form.yml
@@ -1,6 +1,6 @@
 ---
 title: "Rstudio Server"
-cluster: "odyssey3"
+cluster: "academic"
 attributes:
   modules: null
   extra_rstudio_args: ""


### PR DESCRIPTION
on Monday we are making a change on the infrastructure side, changing the deployment of the academic cluster. For consistency we should rename the cluster on the portal hosts and in all the apps that reference it. 