### PR TITLE
Add new packages to base rstudio rocker/verse images for R v4.0.0 and v3.6.3

### DIFF
--- a/Dockerfiles/fasrc_sandbox/rstudio_rockerverse_fasrc_3.6.3/Dockerfile
+++ b/Dockerfiles/fasrc_sandbox/rstudio_rockerverse_fasrc_3.6.3/Dockerfile
@@ -41,6 +41,7 @@ RUN apt-get update \
         libcairo2-dev \
         libtiff5-dev \
         libreadline-dev \
+        libglpk-dev \
         libgsl0-dev \
         libgslcblas0 \
         libgtk2.0-dev \
@@ -131,9 +132,11 @@ RUN apt-get update \
         && rm -rf /var/lib/apt/lists/*
 
 
-## Explicitly requested packages
-RUN install2.r corrplot
-RUN Rscript -e 'devtools::install_github("OI-Biostat/oi_biostat_data")'
+## Explicitly requested packages (e.g. STAT 104, GOV 51)
+RUN install2.r corrplot learnr
+RUN Rscript -e 'devtools::install_github("OI-Biostat/oi_biostat_data")' \
+        && Rscript -e 'devtools::install_github("rstudio-education/gradethis")' \
+        && Rscript -e 'devtools::install_github("kosukeimai/qss-package", build_vignettes=TRUE)'
 
 ## add a couple of collections of latex style files
 RUN tlmgr update --self &&  tlmgr install collection-latex && tlmgr install  collection-latexrecommended && tlmgr install  collection-latexextra

--- a/Dockerfiles/fasrc_sandbox/rstudio_rockerverse_fasrc_4.0.0/Dockerfile
+++ b/Dockerfiles/fasrc_sandbox/rstudio_rockerverse_fasrc_4.0.0/Dockerfile
@@ -41,6 +41,7 @@ RUN apt-get update \
         libcairo2-dev \
         libtiff5-dev \
         libreadline-dev \
+        libglpk-dev \
         libgsl0-dev \
         libgslcblas0 \
         libgtk2.0-dev \
@@ -131,9 +132,11 @@ RUN apt-get update \
         && rm -rf /var/lib/apt/lists/*
 
 
-## Explicitly requested packages
-RUN install2.r corrplot
-RUN Rscript -e 'devtools::install_github("OI-Biostat/oi_biostat_data")'
+## Explicitly requested packages (e.g. STAT 104, GOV 51)
+RUN install2.r corrplot learnr
+RUN Rscript -e 'devtools::install_github("OI-Biostat/oi_biostat_data")' \
+        && Rscript -e 'devtools::install_github("rstudio-education/gradethis")' \
+        && Rscript -e 'devtools::install_github("kosukeimai/qss-package", build_vignettes=TRUE)'
 
 ## add a couple of collections of latex style files
 RUN  tlmgr install collection-latex && tlmgr install  collection-latexrecommended && tlmgr install  collection-latexextra

--- a/form.yml
+++ b/form.yml
@@ -39,8 +39,8 @@ attributes:
     label: "rstudio version"
     help: "select the container you want to run"
     options:
-      - [ "R 4.0.0 - rocker/verse 4.0.0", "rstudio_rockerverse_fasrc_4.0.0/rstudio_rockerverse_fasrc_4.0.0.sif"]
-      - [ "R 3.6.3 - rocker/verse 3.6.3", "rstudio_rockerverse_fasrc_3.6.3/rstudio_rockerverse_fasrc_3.6.3.sif"]
+      - [ "R 4.0.0 - rocker/verse 4.0.0", "rstudio_rockerverse_fasrc_4.0.0/harvardat_atg-rstudio-general_4.0.0-084202c.sif"]
+      - [ "R 3.6.3 - rocker/verse 3.6.3", "rstudio_rockerverse_fasrc_3.6.3/harvardat_atg-rstudio-general_3.6.3-084202c.sif"]
   custom_vanillaconf:
     label: "Start rstudio with a new configuration"
     widget: check_box


### PR DESCRIPTION
The following packages have been added to the general image (requested by GOV51):

- [learnr](https://cran.r-project.org/web/packages/learnr/index.html)
- https://github.com/rstudio-education/gradethis
- https://github.com/kosukeimai/qss (depends on `igraph` which requires `glpk-dev`)

Updated images for R 3.6.3 and 4.0.0 have been pushed to [harvardat/atg-rstudio-general](https://hub.docker.com/r/harvardat/atg-rstudio-general) and tagged with the git commit:
- `harvardat/atg-rstudio-general:3.6.3-084202c`
- `harvardat/atg-rstudio-general:4.0.0-084202c`

@pontiggi Can you share the command you used to generate `list-installed-packages.txt`? I did not update that here (yet).
