### PR TITLE
Gov1005 Rstudio 1.4 upgrade

### DIFF
--- a/form.yml
+++ b/form.yml
@@ -16,7 +16,7 @@ attributes:
     widget: select
     label: "rstudio version"
     options:
-      - [ "R 4.0.3 - Gov1005", "harvardat_rstudio-gov1005_b2f11efa.sif"]
+      - [ "R 4.0.3 - Gov1005", "harvardat_rstudio-gov1005_f6da88d9.sif"]
   custom_vanillaconf: 0
 
 form:

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -77,7 +77,7 @@ mkdir -p $R_LIBS_USER
 # Need a unique /tmp for this job for /tmp/rstudio-rsession & /tmp/rstudio-server
 WORKDIR=/scratch/${USER}/${SLURM_JOB_ID}
 mkdir -m 700 -p ${WORKDIR}/tmp  
-mkdir -p ${WORKDIR}/var/run/{lock/rstudio-server,rstudio-server/rstudio-rsession,mount,systemd} ${WORKDIR}/logs
+mkdir -p ${WORKDIR}/var/run/{lock/rstudio-server,rstudio-server/rstudio-rsession,mount,systemd} ${WORKDIR}/var/lib/rstudio-server ${WORKDIR}/logs 
 
 # https://github.com/rocker-org/rocker-versioned/issues/153
 # override R_LIBS_USER in /etc/R/Renviron.site
@@ -106,11 +106,32 @@ END
 
 chmod +x ${WORKDIR}/rsession.sh
 
+# [Rstudio 1.4] database is required
+cat > ${WORKDIR}/database.conf <<END
+provider=sqlite
+directory=/var/lib/rstudio-server
+END
+
+# [Rstudio 1.4] configure logging
+cat > ${WORKDIR}/logging.conf <<END
+[@rserver]
+log-level=info
+max-size-mb=10
+END
+
+# [Rstudio 1.4] Note that user storage has moved from ~/.rstudio to ~/.local/share/rstudio
+# To keep user storage in the same location, set the RSTUDIO_DATA_HOME env variable.
+# However, it may be best to keep storage separate rather than risking data corruption.
+# See also:
+#     https://docs.rstudio.com/ide/server-pro/r-sessions.html#user-state-storage
+#     https://support.rstudio.com/hc/en-us/articles/360062132513-Rolling-back-to-a-previous-version-from-RStudio-IDE-v1-4 
+# export SINGULARITYENV_RSTUDIO_DATA_HOME="$HOME/.rstudio"
+
 ## some binds that are necessary for running with singularity
-export SING_BINDS=" --bind ${WORKDIR}/logs:/var/log/rstudio-server --bind ${WORKDIR}/var/run:/var/run --bind ${WORKDIR}/tmp:/tmp"
+export SING_BINDS=" --bind ${WORKDIR}/logs:/var/log/rstudio-server --bind ${WORKDIR}/var/run:/var/run --bind ${WORKDIR}/var/lib/rstudio-server:/var/lib/rstudio-server  --bind ${WORKDIR}/tmp:/tmp"
 
 ## use our specific configs
-export SING_BINDS="$SING_BINDS --bind ${WORKDIR}/rserver.conf:/etc/rstudio/rserver.conf --bind ${WORKDIR}/Renviron.site:${R_HOME}/etc/Renviron.site --bind ${WORKDIR}/rsession.sh:/etc/rstudio/rsession.sh"
+export SING_BINDS="$SING_BINDS --bind ${WORKDIR}/rserver.conf:/etc/rstudio/rserver.conf --bind ${WORKDIR}/database.conf:/etc/rstudio/database.conf --bind ${WORKDIR}/Renviron.site:${R_HOME}/etc/Renviron.site --bind ${WORKDIR}/rsession.sh:/etc/rstudio/rsession.sh --bind ${WORKDIR}/logging.conf:/etc/rstudio/logging.conf"
 
 ## users can chose if starting from a fresh config or keep the default in HOME/.rstudio
 <%- if !context.custom_vanillaconf.to_i.zero? -%>

--- a/view.html.erb
+++ b/view.html.erb
@@ -1,9 +1,26 @@
-<form action="/rnode/<%= host %>/<%= port %>/auth-do-sign-in" method="post" target="_blank">
+<form action="/rnode/<%= host %>/<%= port %>/auth-do-sign-in" method="post" target="_blank" onsubmit="return connect_rstudio('/rnode/<%= host %>/<%= port %>', this);">
   <input type="hidden" name="username" value="<%= ENV["USER"] %>">
   <input type="hidden" name="password" value="<%= password %>">
   <input type="hidden" name="staySignedIn" value="1">
-  <input type="hidden" name="appUri" value="">
+  <input type="hidden" name="appUri" value="./">
+  <input type="hidden" name="csrf-token" value="5905efa2-442a-46bf-8703-f35fe8a51888">
   <button class="btn btn-primary" type="submit">
     <i class="fa fa-registered"></i> Connect to RStudio Server
   </button>
 </form>
+<script>
+<%# 
+As of Rstudio 1.4, a CSRF token is required to authenticate. This is normally
+set on the sign-in page, but since we are bypassing the sign-in page and
+POSTing directly, we need to ensure that the CSRF token cookie is set ahead of
+time (i.e. just before the form submission).  When Rstudio receives the POST
+request, it will compare the POSTed csrf token against the value of the cookie. 
+%>
+function connect_rstudio(path, form) {
+  const csrf_token = form.elements['csrf-token'].value;
+  const new_cookie = `csrf-token=${csrf_token}; path=${path}; secure`;
+  console.log("Setting Rstudio csrf-token cookie:", new_cookie);
+  document.cookie = new_cookie;
+  return true;
+}
+</script>


### PR DESCRIPTION
This PR updates the app configuration to support RStudio 1.4. Changes include:
- Added `database.conf` configuration and bind location `/var/lib/rstudio-server`.
- Added `logging.conf` configuration and bind location `/var/log/rstudio-server`.
- Updated connection `view.html.erb` to set the [required csrf token](https://github.com/rstudio/rstudio/commit/3bfe2801ebeb3b46d71a3459d5ff546f87b1a305) and associated cookie before POSTing the username/password. If the cookie is not set beforehand, the user will be redirected to the sign in page where they will see a message that says  _Error: Temporary server error, please try again_.

Also note that [user state storage](https://docs.rstudio.com/ide/server-pro/r-sessions.html#user-state-storage) has been moved from `~/.rstudio` to `~/.local/share/rstudio` which has implications for learnr tutorial session state. We could force Rstudio to continue using `~/.rstudio`, but this seems dicey given that we don't know if the state structure has changed between 1.3 and 1.4. To prevent potential corruption, it would be better to keep the storage locations separate, so if we have to rollback for any reason, we can without risking further corruption.