### PR TITLE
Added support for Rstudio 2021.09.0 "Ghost Orchid" Release.

### DIFF
--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -24,7 +24,7 @@ mkdir -p $R_LIBS_USER
 # Need a unique /tmp for this job for /tmp/rstudio-rsession & /tmp/rstudio-server
 WORKDIR=/scratch/${USER}/${SLURM_JOB_ID}
 mkdir -m 700 -p ${WORKDIR}/tmp  
-mkdir -p ${WORKDIR}/var/run/{lock/rstudio-server,rstudio-server/rstudio-rsession,mount,systemd} ${WORKDIR}/var/lib/rstudio-server ${WORKDIR}/logs
+mkdir -p ${WORKDIR}/var/run/{lock/rstudio-server,rstudio-server/rstudio-rsession,mount,systemd} ${WORKDIR}/var/lib/rstudio-server ${WORKDIR}/logs/{rstudio,rstudio-server}
 
 # https://github.com/rocker-org/rocker-versioned/issues/153
 # override R_LIBS_USER in /etc/R/Renviron.site
@@ -67,7 +67,7 @@ max-size-mb=10
 END
 
 ## some binds that are necessary for running with singularity
-export SING_BINDS=" --bind ${WORKDIR}/logs:/var/log/rstudio-server --bind ${WORKDIR}/var/run:/var/run --bind ${WORKDIR}/var/lib/rstudio-server:/var/lib/rstudio-server  --bind ${WORKDIR}/tmp:/tmp"
+export SING_BINDS=" --bind ${WORKDIR}/logs/rstudio-server:/var/log/rstudio-server --bind ${WORKDIR}/logs/rstudio:/var/log/rstudio --bind ${WORKDIR}/var/run:/var/run --bind ${WORKDIR}/var/lib/rstudio-server:/var/lib/rstudio-server  --bind ${WORKDIR}/tmp:/tmp"
 
 ## use our specific configs
 export SING_BINDS="$SING_BINDS --bind ${WORKDIR}/rserver.conf:/etc/rstudio/rserver.conf --bind ${WORKDIR}/database.conf:/etc/rstudio/database.conf --bind ${WORKDIR}/Renviron.site:${R_HOME}/etc/Renviron.site --bind ${WORKDIR}/rsession.sh:/etc/rstudio/rsession.sh --bind ${WORKDIR}/logging.conf:/etc/rstudio/logging.conf"
@@ -89,6 +89,7 @@ singularity exec --cleanenv \
  "${container_image}" \
  sh -c "USER=${USER}
  rserver \
+ --server-user ${USER} \
  --www-port ${port} \
  --auth-none 0 \
  --auth-encrypt-password 0 \


### PR DESCRIPTION
This PR fixes some issues that have arisen with the September 2021 release of Rstudio (e.g. [Ghost Orchid](https://community.rstudio.com/t/rstudio-2021-09-0-ghost-orchid-update-whats-new-doing-more-when-r-is-busy-logging-changes-and-load-balancing-improvements/116667)). The previous release was [v1.4.1717](https://github.com/rstudio/rstudio/releases/tag/v1.4.1717). Rstudio has switched to a calendar-based versioning strategy.

**Changes:**

- Updated singularity binds for logs since they have been moved to a new location: `/var/log/rstudio`. The `rserver.log`, however, is still found in `/var/log/rstudio-server`, so we need binds for both.
- Added the `--server-user `option when starting `rserver` so that it does not try to run as user `rstudio-server`, whcih will result in a different UID from the actual user and generate an ERROR. 